### PR TITLE
add youtube-music theme file check

### DIFF
--- a/modules/programs/media/youtube-music/default.nix
+++ b/modules/programs/media/youtube-music/default.nix
@@ -151,11 +151,13 @@
 
       # Fetch the theme
       home.activation.fetchYoutubeTheme = lib.mkAfter ''
-        export PATH=${pkgs.curl}/bin:$PATH
-        THEME_DIR="$HOME/.config/YouTube Music/themes"
-        THEME_FILE="$THEME_DIR/catppuccin-mocha.css"
-        mkdir -p "$THEME_DIR"
-        curl -sSfL "https://raw.githubusercontent.com/catppuccin/youtubemusic/main/src/macchiato.css" -o "$THEME_FILE"
+        if ! [ -f "$HOME/.config/YouTube Music/themes/catppuccin-mocha.css" ]; then
+          export PATH=${pkgs.curl}/bin:$PATH
+          THEME_DIR="$HOME/.config/YouTube Music/themes"
+          THEME_FILE="$THEME_DIR/catppuccin-mocha.css"
+          mkdir -p "$THEME_DIR"
+          curl -sSfL "https://raw.githubusercontent.com/catppuccin/youtubemusic/main/src/macchiato.css" -o "$THEME_FILE"
+        fi
       '';
 
       # make the config writable (may cause home-manager conflicts)


### PR DESCRIPTION
During Linux boot, the home-manager service was failing because it could not run curl.

As a workaround, an arrangement has been made to not download the file if it exists.